### PR TITLE
#157694754 Add failed jobs page

### DIFF
--- a/hc/front/tests/test_my_checks.py
+++ b/hc/front/tests/test_my_checks.py
@@ -58,3 +58,10 @@ class MyChecksTestCase(BaseTestCase):
 
         # Mobile
         self.assertContains(r, "label-warning")
+    
+    def test_issues_page(self):
+        """Test unresolved issues page"""
+        self.client.login(username="alice@example.org", password="password")
+        url = "/issues/"
+        r = self.client.get(url)
+        self.assertEqual(r.status_code, 200)

--- a/hc/front/urls.py
+++ b/hc/front/urls.py
@@ -34,6 +34,7 @@ urlpatterns = [
     url(r'^checks/add/$', views.add_check, name="hc-add-check"),
     url(r'^checks/([\w-]+)/', include(check_urls)),
     url(r'^integrations/', include(channel_urls)),
+    url(r'^issues/', views.unresolved_issues, name="issues"),
 
     url(r'^docs/$', views.docs, name="hc-docs"),
     url(r'^docs/api/$', views.docs_api, name="hc-docs-api"),

--- a/hc/front/views.py
+++ b/hc/front/views.py
@@ -552,3 +552,18 @@ def privacy(request):
 
 def terms(request):
     return render(request, "front/terms.html", {})
+
+@login_required
+def unresolved_issues(request):
+    ''' Handle unresolved issues '''
+    assert request.method == "GET"
+    q = Check.objects.filter(user=request.team.user).order_by("created")
+
+    checks = [ check for check in q if check.get_status() is "down"]
+
+    ctx = {
+        "page": "issues",
+        "checks": checks,
+        "ping_endpoint": settings.PING_ENDPOINT,
+    }
+    return render(request, "front/issues.html", ctx)

--- a/static/js/issues.js
+++ b/static/js/issues.js
@@ -1,0 +1,137 @@
+$(function () {
+
+    var MINUTE = { name: "minute", nsecs: 60 };
+    var HOUR = { name: "hour", nsecs: MINUTE.nsecs * 60 };
+    var DAY = { name: "day", nsecs: HOUR.nsecs * 24 };
+    var WEEK = { name: "week", nsecs: DAY.nsecs * 7 };
+    var UNITS = [WEEK, DAY, HOUR, MINUTE];
+
+    var secsToText = function (total) {
+        var remainingSeconds = Math.floor(total);
+        var result = "";
+        for (var i = 0, unit; unit = UNITS[i]; i++) {
+            if (unit === WEEK && remainingSeconds % unit.nsecs != 0) {
+                // Say "8 days" instead of "1 week 1 day"
+                continue
+            }
+
+            var count = Math.floor(remainingSeconds / unit.nsecs);
+            remainingSeconds = remainingSeconds % unit.nsecs;
+
+            if (count == 1) {
+                result += "1 " + unit.name + " ";
+            }
+
+            if (count > 1) {
+                result += count + " " + unit.name + "s ";
+            }
+        }
+
+        return result;
+    }
+
+
+
+
+
+    $('[data-toggle="tooltip"]').tooltip();
+
+    $(".my-checks-name").click(function () {
+        var $this = $(this);
+
+        $("#update-name-form").attr("action", $this.data("url"));
+        $("#update-name-input").val($this.data("name"));
+        $("#update-tags-input").val($this.data("tags"));
+        $('#update-name-modal').modal("show");
+        $("#update-name-input").focus();
+
+        return false;
+    });
+
+    $(".check-menu-remove").click(function () {
+        var $this = $(this);
+
+        $("#remove-check-form").attr("action", $this.data("url"));
+        $(".remove-check-name").text($this.data("name"));
+        $('#remove-check-modal').modal("show");
+
+        return false;
+    });
+
+
+    $("#my-checks-tags button").click(function () {
+        // .active has not been updated yet by bootstrap code,
+        // so cannot use it
+        $(this).toggleClass('checked');
+
+        // Make a list of currently checked tags:
+        var checked = [];
+        $("#my-checks-tags button.checked").each(function (index, el) {
+            checked.push(el.textContent);
+        });
+
+        // No checked tags: show all
+        if (checked.length == 0) {
+            $("#checks-table tr.checks-row").show();
+            $("#checks-list > li").show();
+            return;
+        }
+
+        function applyFilters(index, element) {
+            var tags = $(".my-checks-name", element).data("tags").split(" ");
+            for (var i = 0, tag; tag = checked[i]; i++) {
+                if (tags.indexOf(tag) == -1) {
+                    $(element).hide();
+                    return;
+                }
+            }
+
+            $(element).show();
+        }
+
+        // Desktop: for each row, see if it needs to be shown or hidden
+        $("#checks-table tr.checks-row").each(applyFilters);
+        // Mobile: for each list item, see if it needs to be shown or hidden
+        $("#checks-list > li").each(applyFilters);
+
+    });
+
+    $(".pause-check").click(function (e) {
+        var url = e.target.getAttribute("data-url");
+        $("#pause-form").attr("action", url).submit();
+        return false;
+    });
+
+
+    $(".usage-examples").click(function (e) {
+        var a = e.target;
+        var url = a.getAttribute("data-url");
+        var email = a.getAttribute("data-email");
+
+        $(".ex", "#show-usage-modal").text(url);
+        $(".em", "#show-usage-modal").text(email);
+
+        $("#show-usage-modal").modal("show");
+        return false;
+    });
+
+
+    var clipboard = new Clipboard('button.copy-link');
+    $("button.copy-link").mouseout(function (e) {
+        setTimeout(function () {
+            e.target.textContent = "copy";
+        }, 300);
+    })
+
+    clipboard.on('success', function (e) {
+        e.trigger.textContent = "copied!";
+        e.clearSelection();
+    });
+
+    clipboard.on('error', function (e) {
+        var text = e.trigger.getAttribute("data-clipboard-text");
+        prompt("Press Ctrl+C to select:", text)
+    });
+
+
+});

--- a/static/js/issues.js
+++ b/static/js/issues.js
@@ -30,10 +30,6 @@ $(function () {
         return result;
     }
 
-
-
-
-
     $('[data-toggle="tooltip"]').tooltip();
 
     $(".my-checks-name").click(function () {
@@ -57,7 +53,6 @@ $(function () {
 
         return false;
     });
-
 
     $("#my-checks-tags button").click(function () {
         // .active has not been updated yet by bootstrap code,
@@ -102,7 +97,6 @@ $(function () {
         return false;
     });
 
-
     $(".usage-examples").click(function (e) {
         var a = e.target;
         var url = a.getAttribute("data-url");
@@ -114,7 +108,6 @@ $(function () {
         $("#show-usage-modal").modal("show");
         return false;
     });
-
 
     var clipboard = new Clipboard('button.copy-link');
     $("button.copy-link").mouseout(function (e) {
@@ -132,6 +125,5 @@ $(function () {
         var text = e.trigger.getAttribute("data-clipboard-text");
         prompt("Press Ctrl+C to select:", text)
     });
-
 
 });

--- a/templates/base.html
+++ b/templates/base.html
@@ -77,6 +77,10 @@
                         <a href="{% url 'hc-checks' %}">Checks</a>
                     </li>
 
+                    <li {% if page == 'issues' %} class="active" {% endif %}>
+                        <a href="{% url 'issues' %}">Issues</a>
+                    </li>
+
                     <li {% if page == 'channels' %} class="active" {% endif %}>
                         <a href="{% url 'hc-channels' %}">Integrations</a>
                     </li>

--- a/templates/front/issues.html
+++ b/templates/front/issues.html
@@ -1,0 +1,119 @@
+{% extends "base.html" %}
+{% load compress staticfiles %}
+
+{% block title %}Unresolved checks - healthchecks.io{% endblock %}
+
+
+{% block content %}
+<div class="row">
+    <div class="col-sm-12">
+        <h1>
+        {% if request.team == request.user.profile %}
+            Unresolved checks
+        {% else %}
+            {{ request.team.team_name }}
+        {% endif %}
+        </h1>
+    </div>
+
+</div>
+<div class="row">
+    <div class="col-sm-12">
+
+
+    {% if checks %}
+        {% include "front/issues_mobile.html" %}
+        {% include "front/issues_desktop.html" %}
+    {% else %}
+    <div class="alert alert-info">You don't have any any unresolved checks.</div>
+    {% endif %}
+    </div>
+</div>
+
+<div id="show-usage-modal" class="modal">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal">&times;</button>
+                <ul class="nav nav-pills" role="tablist">
+                    <li class="active">
+                        <a href="#crontab" data-toggle="tab">Crontab</a>
+                    </li>
+                    <li>
+                        <a href="#bash" data-toggle="tab">Bash</a>
+                    </li>
+                    <li>
+                        <a href="#python" data-toggle="tab">Python</a>
+                    </li>
+                    <li class="hidden-xs">
+                        <a href="#node" data-toggle="tab">Node.js</a>
+                    </li>
+                    <li class="hidden-xs">
+                        <a href="#php" data-toggle="tab">PHP</a>
+                    </li>
+                    <li class="hidden-xs">
+                        <a href="#browser" data-toggle="tab">Browser</a>
+                    </li>
+                    <li class="hidden-xs">
+                        <a href="#powershell" data-toggle="tab">PowerShell</a>
+                    </li>
+                    <li class="hidden-xs">
+                        <a href="#email" data-toggle="tab">Email</a>
+                    </li>
+                </ul>
+
+            </div>
+            <div class="modal-body">
+
+
+                <div class="tab-content">
+                    {% with ping_url="<span class='ex'></span>" %}
+                    <div role="tabpanel" class="tab-pane active" id="crontab">
+                        {% include "front/snippets/crontab.html" %}
+                    </div>
+                    <div role="tabpanel" class="tab-pane" id="bash">
+                        {% include "front/snippets/bash.html" %}
+                    </div>
+                    <div role="tabpanel" class="tab-pane" id="python">
+                        {% include "front/snippets/python.html" %}
+                    </div>
+                    <div role="tabpanel" class="tab-pane" id="node">
+                        {% include "front/snippets/node.html" %}
+                    </div>
+                    <div role="tabpanel" class="tab-pane" id="php">
+                        {% include "front/snippets/php.html" %}
+                    </div>
+                    <div class="tab-pane" id="browser">
+                        {% include "front/snippets/browser.html" %}
+                    </div>
+                    <div class="tab-pane" id="powershell">
+                        {% include "front/snippets/powershell.html" %}
+                    </div>
+                    <div class="tab-pane" id="email">
+                            As an alternative to HTTP/HTTPS requests,
+                            you can "ping" this check by sending an
+                            email message to
+                            <div class="email-address">
+                                <code class="em"></code>
+                            </div>
+                    </div>
+                    {% endwith %}
+                </div>
+
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Got It!</button>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+{% compress js %}
+<script src="{% static 'js/jquery-2.1.4.min.js' %}"></script>
+<script src="{% static 'js/bootstrap.min.js' %}"></script>
+<script src="{% static 'js/clipboard.min.js' %}"></script>
+<script src="{% static 'js/issues.js' %}"></script>
+{% endcompress %}
+{% endblock %}

--- a/templates/front/issues_desktop.html
+++ b/templates/front/issues_desktop.html
@@ -1,0 +1,68 @@
+{% load hc_extras humanize %}
+<table id="checks-table" class="table hidden-xs">
+    <tr>
+        <th></th>
+        <th class="th-name">Name</th>
+        <th>Ping URL</th>
+        <th>Last Ping</th>
+    </tr>
+    {% for check in checks %}
+    <tr class="checks-row">
+        <td class="indicator-cell">
+          <span class="status icon-down"></span>
+        </td>
+        <td class="name-cell">
+            <div data-name="{{ check.name }}"
+                    data-tags="{{ check.tags }}"
+                    data-url="{% url 'hc-update-name' check.code %}"
+                    class="my-checks-name {% if not check.name %}unnamed{% endif %}">
+                <div>{{ check.name|default:"unnamed" }}</div>
+                {% for tag in check.tags_list %}
+                <span class="label label-tag">{{ tag }}</span>
+                {% endfor %}
+            </div>
+        </td>
+        <td class="url-cell">
+            <span class="my-checks-url">
+                <span class="base">{{ ping_endpoint }}</span>{{ check.code }}
+            </span>
+            <button
+                class="copy-link hidden-sm"
+                data-clipboard-text="{{ check.url }}">
+                copy
+            </button>
+        </td>
+        <td>
+          <span
+              data-toggle="tooltip"
+              title="{{ check.last_ping|date:'N j, Y, P e' }}">
+              {{ check.last_ping|naturaltime }}
+          </span>
+        </td>
+        <td>
+            <div class="check-menu dropdown">
+                <button class="btn btn-sm btn-default dropdown-toggle" type="button" data-toggle="dropdown">
+                <span class="icon-settings" aria-hidden="true"></span>
+                </button>
+                <ul class="dropdown-menu">
+                    <li>
+                        <a href="{% url 'hc-log' check.code %}">
+                            Log
+                        </a>
+                    </li>
+                    <li>
+                        <a
+                            href="#"
+                            class="usage-examples"
+                            data-url="{{ check.url }}"
+                            data-email="{{ check.email }}">
+                            Usage Examples
+                        </a>
+                    </li>
+                </ul>
+            </div>
+        </td>
+    </tr>
+    {% endfor %}
+
+</table>

--- a/templates/front/issues_mobile.html
+++ b/templates/front/issues_mobile.html
@@ -1,0 +1,47 @@
+{% load hc_extras humanize %}
+
+<ul id="checks-list" class="visible-xs">
+    {% for check in checks %}
+    <li>
+        <h2>
+            <span class="{% if not check.name %}unnamed{% endif %}">
+                {{ check.name|default:"unnamed" }}
+            </span>
+
+            <code>{{ check.code }}</code>
+        </h2>
+        
+        <table class="table">
+            <tr>
+                <th>Status</th>
+                <td>
+                  <span class="label label-danger">DOWN</span>
+                </td>
+            </tr>
+            {% if check.tags %}
+            <tr>
+                <th>Tags</th>
+                <td>
+                    {% for tag in check.tags_list %}
+                    <span class="label label-tag">{{ tag }}</span>
+                    {% endfor %}
+                </td>
+            </tr>
+            {% endif %}
+            <tr>
+                <th>Last Ping</th>
+                <td>
+                  {{ check.last_ping|naturaltime }}
+                </td>
+            </tr>
+        </table>
+
+        <div>
+
+          <a href="{% url 'hc-log' check.code %}" class="btn btn-default">Log</a>
+
+        </div>
+
+    </li>
+    {% endfor %}
+</ul>


### PR DESCRIPTION
#### What does this PR do?
- Add a tab in the links for the failed jobs(Issues)
- Add a page for the failed jobs
- Add tests for the failed job feature

#### Description of Task to be completed?
A user can click an issue tab/link and view listing of all their failed jobs
#### How should this be manually tested?
- Run the application and click the issues link to view the failed jobs/checks
- Test the added feature by running `./manage.py test hc.front.tests.test_my_checks`
#### What are the relevant pivotal tracker stories?
[#157694754](https://www.pivotaltracker.com/story/show/157694754)
#### Screenshot
<img width="1280" alt="screen shot 2018-06-07 at 20 36 38" src="https://user-images.githubusercontent.com/5815755/41116314-9f9c43da-6a92-11e8-8cd0-3178c396bc0d.png">
