### PR TITLE
#157694755 Extend timeout, grace and nag periods to exceed 30 days

### DIFF
--- a/hc/front/forms.py
+++ b/hc/front/forms.py
@@ -19,9 +19,9 @@ class NameTagsForm(forms.Form):
 
 class TimeoutForm(forms.Form):
 
-    timeout = forms.IntegerField(min_value=60, max_value=3456000)
-    grace = forms.IntegerField(min_value=60, max_value=3456000)
-    nag = forms.IntegerField(min_value=60, max_value=3456000)
+    timeout = forms.IntegerField(min_value=60)
+    grace = forms.IntegerField(min_value=60)
+    nag = forms.IntegerField(min_value=60)
 
 
 

--- a/hc/front/tests/test_update_timeout.py
+++ b/hc/front/tests/test_update_timeout.py
@@ -11,7 +11,7 @@ class UpdateTimeoutTestCase(BaseTestCase):
 
     def test_it_works(self):
         url = "/checks/%s/timeout/" % self.check.code
-        payload = {"timeout": 3600, "grace": 60}
+        payload = {"timeout": 3600, "grace": 60, "nag": 60}
 
         self.client.login(username="alice@example.org", password="password")
         r = self.client.post(url, data=payload)
@@ -24,19 +24,20 @@ class UpdateTimeoutTestCase(BaseTestCase):
     # Test setting timeout and grace period of more than 30 days - (38 as an example)
     def test_user_can_set_timeout_and_grace_period_above_30_days(self):
         url = "/checks/%s/timeout/" % self.check.code
-        payload = {"timeout": 3024000, "grace": 3024000}
+        payload = {"timeout": 3024000, "grace": 3024000, "nag": 60}
 
         self.client.login(username="alice@example.org", password="password")
         r = self.client.post(url, data=payload)
         self.assertRedirects(r, "/checks/")
 
         check = Check.objects.get(code=self.check.code)
+
         assert check.timeout.total_seconds() == 3024000
         assert check.grace.total_seconds() == 3024000
 
     def test_team_access_works(self):
         url = "/checks/%s/timeout/" % self.check.code
-        payload = {"timeout": 7200, "grace": 60}
+        payload = {"timeout": 7200, "grace": 60, "nag": 60}
 
         # Logging in as bob, not alice. Bob has team access so this
         # should work.

--- a/static/css/bootstrap.css
+++ b/static/css/bootstrap.css
@@ -4704,13 +4704,13 @@ button.close {
   outline: 0;
 }
 .days{
-  width:25%;
+  width:55%;
   border-radius: 5px;
   float: right;
 }
 #manual-slider {
   margin-left:6%;
-  width:18%
+  width:28%
 }
 .modal.fade .modal-dialog {
   -webkit-transform: translate(0, -25%);

--- a/static/css/bootstrap.css
+++ b/static/css/bootstrap.css
@@ -4703,6 +4703,15 @@ button.close {
   -webkit-overflow-scrolling: touch;
   outline: 0;
 }
+.days{
+  width:25%;
+  border-radius: 5px;
+  float: right;
+}
+#manual-slider {
+  margin-left:6%;
+  width:18%
+}
 .modal.fade .modal-dialog {
   -webkit-transform: translate(0, -25%);
   -ms-transform: translate(0, -25%);

--- a/static/js/checks.js
+++ b/static/js/checks.js
@@ -61,16 +61,22 @@ $(function () {
     periodSlider.noUiSlider.on("change", function (a, b, value) {
         var rounded = Math.round(value);
         if (value < 3600 * 24) { $("#days").val(1); }
-        else { $("#days").val(rounded / (3600 * 24)); }
+        else { $("#days").val(rounded / (3600 * 24));
+        periodSlider.removeAttribute('disabled'); }
     });
     $('#days').change(function () {
         
         var rounded = this.value * 3600 * 24;
         if (rounded <= 2592000)
-        {periodSlider.noUiSlider.set(rounded);}
+        {
+            periodSlider.noUiSlider.set(rounded);
+            periodSlider.removeAttribute('disabled');
+        }
         else
-        {$("#period-slider-value").text(secsToText(rounded));
-        $("#update-timeout-timeout").val(rounded);}
+        {
+        $("#period-slider-value").text(secsToText(rounded));
+        $("#update-timeout-timeout").val(rounded);
+        periodSlider.setAttribute('disabled', true);}
         
     });
 
@@ -97,12 +103,14 @@ $(function () {
 
     graceSlider.noUiSlider.on("update", function(a, b, value) {
         var rounded = Math.round(value);
+        graceSlider.removeAttribute('disabled');
         $("#grace-slider-value").text(secsToText(rounded));
         $("#update-timeout-grace").val(rounded);
     });
 
     graceSlider.noUiSlider.on("change", function (a, b, value) {
         var rounded = Math.round(value);
+        graceSlider.removeAttribute('disabled');
         if (value < 3600 * 24) { $("#gracedays").val(1); }
         else { $("#gracedays").val(rounded / (3600 * 24)); }
     });
@@ -116,7 +124,9 @@ $(function () {
         else
         
         {$("#grace-slider-value").text(secsToText(rounded));
-        $("#update-timeout-grace").val(rounded);}
+        $("#update-timeout-grace").val(rounded);
+        graceSlider.setAttribute('disabled', true);}
+        
         
     });
 
@@ -144,12 +154,14 @@ $(function () {
 
     nagSlider.noUiSlider.on("update", function(a, b, value) {
         var rounded = Math.round(value);
+        nagSlider.removeAttribute('disabled');
         $("#nag-slider-value").text(secsToText(rounded));
         $("#update-timeout-nag").val(rounded);
     });
 
     nagSlider.noUiSlider.on("change", function (a, b, value) {
         var rounded = Math.round(value);
+        nagSlider.removeAttribute('disabled');
         if (value < 3600 * 24) { $("#nagdays").val(1); }
         else { $("#nagdays").val(rounded / (3600 * 24)); }
     });
@@ -163,7 +175,9 @@ $(function () {
         else
         
         {$("#nag-slider-value").text(secsToText(rounded));
-        $("#update-timeout-nag").val(rounded);}
+        $("#update-timeout-nag").val(rounded);
+        nagSlider.setAttribute('disabled', true);}
+        
         
     });
 

--- a/static/js/checks.js
+++ b/static/js/checks.js
@@ -1,5 +1,6 @@
 $(function () {
-
+    
+      
     var MINUTE = {name: "minute", nsecs: 60};
     var HOUR = {name: "hour", nsecs: MINUTE.nsecs * 60};
     var DAY = {name: "day", nsecs: HOUR.nsecs * 24};
@@ -36,19 +37,13 @@ $(function () {
         connect: "lower",
         range: {
             'min': [60, 60],
-            '27%': [3600, 3600],
-            '52%': [86400, 86400],
-            '64%': [604800, 604800],
-            '76%': [2592000, 2592000],
-            '80%': [2764800, 2764800],
-            '85%': [2937600, 2937600],
-            '90%': [3110400, 3110400],
-            '95%': [3283200, 3283200],
-            'max': 3456000,
+            '33%': [3600, 3600], 
+            '66%': [86400, 86400], 
+            'max': 2592000,
         },
         pips: {
             mode: 'values',
-            values: [60, 1800, 3600, 43200, 86400, 604800, 2592000, 3024001, 3456000],
+            values: [60, 1800, 3600, 43200, 86400, 1296000, 2592000],
             density: 4,
             format: {
                 to: secsToText,
@@ -62,7 +57,16 @@ $(function () {
         $("#period-slider-value").text(secsToText(rounded));
         $("#update-timeout-timeout").val(rounded);
     });
-
+    
+    periodSlider.noUiSlider.on("change", function (a, b, value) {
+        var rounded = Math.round(value);
+        if (value < 3600 * 24) { $("#days").val(1); }
+        else { $("#days").val(rounded / (3600 * 24)); }
+    });
+    $('#days').change(function () {
+        
+        periodSlider.noUiSlider.set(this.value * 3600 * 24);
+    });
 
     var graceSlider = document.getElementById("grace-slider");
     noUiSlider.create(graceSlider, {
@@ -70,19 +74,13 @@ $(function () {
         connect: "lower",
         range: {
             'min': [60, 60],
-            '27%': [3600, 3600],
-            '52%': [86400, 86400],
-            '64%': [604800, 604800],
-            '76%': [2592000, 2592000],
-            '80%': [2764800, 2764800],
-            '85%': [2937600, 2937600],
-            '90%': [3110400, 3110400],
-            '95%': [3283200, 3283200],
-            'max': 3456000,
+            '33%': [3600, 3600], 
+            '66%': [86400, 86400], 
+            'max': 2592000,
         },
         pips: {
             mode: 'values',
-            values: [60, 1800, 3600, 43200, 86400, 604800, 2592000, 3024001, 3456000],
+            values: [60, 1800, 3600, 43200, 86400, 1296000, 2592000],
             density: 4,
             format: {
                 to: secsToText,
@@ -97,20 +95,39 @@ $(function () {
         $("#update-timeout-grace").val(rounded);
     });
 
+    graceSlider.noUiSlider.on("change", function (a, b, value) {
+        var rounded = Math.round(value);
+        if (value < 3600 * 24) { $("#gracedays").val(1); }
+        else { $("#gracedays").val(rounded / (3600 * 24)); }
+    });
+
+    
+    $('#gracedays').change(function () {
+        
+        var rounded = this.value * 3600 * 24;
+        if (rounded <= 2592000)
+        {graceSlider.noUiSlider.set(rounded);}
+        else
+        
+        {$("#grace-slider-value").text(secsToText(rounded));
+        $("#update-timeout-grace").val(rounded);}
+        
+    });
+
+    
     var nagSlider = document.getElementById("nag-slider");
     noUiSlider.create(nagSlider, {
         start: [20],
         connect: "lower",
         range: {
             'min': [60, 60],
-            '33%': [3600, 3600],
-            '66%': [86400, 86400],
-            '83%': [604800, 604800],
+            '33%': [3600, 3600], 
+            '66%': [86400, 86400], 
             'max': 2592000,
         },
         pips: {
             mode: 'values',
-            values: [60, 1800, 3600, 43200, 86400, 604800, 2592000],
+            values: [60, 1800, 3600, 43200, 86400, 1296000, 2592000],
             density: 4,
             format: {
                 to: secsToText,
@@ -125,6 +142,24 @@ $(function () {
         $("#update-timeout-nag").val(rounded);
     });
 
+    nagSlider.noUiSlider.on("change", function (a, b, value) {
+        var rounded = Math.round(value);
+        if (value < 3600 * 24) { $("#nagdays").val(1); }
+        else { $("#nagdays").val(rounded / (3600 * 24)); }
+    });
+
+    
+    $('#nagdays').change(function () {
+        
+        var rounded = this.value * 3600 * 24;
+        if (rounded <= 2592000)
+        {nagSlider.noUiSlider.set(rounded);}
+        else
+        
+        {$("#nag-slider-value").text(secsToText(rounded));
+        $("#update-timeout-nag").val(rounded);}
+        
+    });
 
     $('[data-toggle="tooltip"]').tooltip();
 

--- a/static/js/checks.js
+++ b/static/js/checks.js
@@ -65,7 +65,13 @@ $(function () {
     });
     $('#days').change(function () {
         
-        periodSlider.noUiSlider.set(this.value * 3600 * 24);
+        var rounded = this.value * 3600 * 24;
+        if (rounded <= 2592000)
+        {periodSlider.noUiSlider.set(rounded);}
+        else
+        {$("#period-slider-value").text(secsToText(rounded));
+        $("#update-timeout-timeout").val(rounded);}
+        
     });
 
     var graceSlider = document.getElementById("grace-slider");

--- a/templates/front/my_checks.html
+++ b/templates/front/my_checks.html
@@ -134,7 +134,7 @@
                     </div>
                     <div id="manual-slider">
                         {% for check in checks %}
-                        Timeout Days: <input type="number" min="1" max="40" id="days" class="days" value= {{check.timeout}} >
+                        Timeout Days: <input type="number" min="1" id="days" class="days" value= {{check.timeout}} >
                         {% endfor %}
                     </div>
                     <div id="period-slider"></div>
@@ -155,7 +155,7 @@
 
                     <div id="manual-slider">
                         {% for check in checks %}
-                        Grace Days: <input type="number" min="1" max="40" id="gracedays" class="days" value= {{check.grace}}>
+                        Grace Days: <input type="number" min="1" id="gracedays" class="days" value= {{check.grace}}>
                         {% endfor %}
                     </div>
 
@@ -175,7 +175,7 @@
                         </span>
                     </div>
                     <div id="manual-slider">
-                        Nag Days: <input type="number" min="1" max="40" id="nagdays" class="days" >
+                        Nag Days: <input type="number" min="1" id="nagdays" class="days" value= {{check.nag}}>
                     </div>
                     <div id="nag-slider"></div>
 

--- a/templates/front/my_checks.html
+++ b/templates/front/my_checks.html
@@ -133,7 +133,9 @@
                         </span>
                     </div>
                     <div id="manual-slider">
-                        Timeout Days: <input type="number" min="1" max="40" id="days" class="days">
+                        {% for check in checks %}
+                        Timeout Days: <input type="number" min="1" max="40" id="days" class="days" value= {{check.timeout}} >
+                        {% endfor %}
                     </div>
                     <div id="period-slider"></div>
 
@@ -152,7 +154,9 @@
                     </div>
 
                     <div id="manual-slider">
-                        Grace Days: <input type="number" min="1" max="40" id="gracedays" class="days" >
+                        {% for check in checks %}
+                        Grace Days: <input type="number" min="1" max="40" id="gracedays" class="days" value= {{check.grace}}>
+                        {% endfor %}
                     </div>
 
                     <div id="grace-slider"></div>

--- a/templates/front/my_checks.html
+++ b/templates/front/my_checks.html
@@ -132,6 +132,9 @@
                             1 day
                         </span>
                     </div>
+                    <div id="manual-slider">
+                        Timeout Days: <input type="number" min="1" max="40" id="days" class="days">
+                    </div>
                     <div id="period-slider"></div>
 
                     <div class="update-timeout-info text-center">
@@ -148,6 +151,10 @@
                         </span>
                     </div>
 
+                    <div id="manual-slider">
+                        Grace Days: <input type="number" min="1" max="40" id="gracedays" class="days" >
+                    </div>
+
                     <div id="grace-slider"></div>
 
                     <div class="update-timeout-info text-center">
@@ -162,6 +169,9 @@
                             class="update-timeout-value">
                             1 day
                         </span>
+                    </div>
+                    <div id="manual-slider">
+                        Nag Days: <input type="number" min="1" max="40" id="nagdays" class="days" >
                     </div>
                     <div id="nag-slider"></div>
 


### PR DESCRIPTION
#### What does this PR do?
Adds an input field to allow filling in of unlimited number of days on timeout, grace and nag slider

#### Description of Task to be completed?
Adds an input field for adding days manually, which when added, automatically adjusts the slider time to correspond to the day added. In case the days selected exceeds the slider maximum value which is 30 days, the slider value is unconsidered and the input field's value is saved instead.

#### How should this be manually tested?
Run the tests using the command:
``` ./manage.py test hc.front.tests.test_update_timeout```

#### What are the relevant pivotal tracker stories?
[#157694755](https://www.pivotaltracker.com/story/show/157694755)

#### Screenshots
<img width="550" alt="deactivated slider" src="https://user-images.githubusercontent.com/20478530/41233681-d8b6e668-6d92-11e8-94bb-60dd2bef4157.png">
<img width="604" alt="screen shot 2018-06-11 at 16 16 14" src="https://user-images.githubusercontent.com/20478530/41233690-dbb6303a-6d92-11e8-9c77-741c6f69f597.png">
<img width="821" alt="screen shot 2018-06-11 at 16 07 27" src="https://user-images.githubusercontent.com/20478530/41233694-dd5c122e-6d92-11e8-8fd7-8d9fc44aec34.png">

